### PR TITLE
feat: make multihopTtl parametrizable and raise the default value to 16

### DIFF
--- a/client.go
+++ b/client.go
@@ -60,7 +60,7 @@ func NewClient(c string, ips *[]IPNet) (*Client, error) {
 }
 
 // AddRs adds route-server peerings to the bgp session
-func (c *Client) AddRs(rs string) error {
+func (c *Client) AddRs(rs string, multihop uint32) error {
 	n := &api.Peer{
 		ApplyPolicy: &api.ApplyPolicy{
 			ExportPolicy: &api.PolicyAssignment{
@@ -81,7 +81,7 @@ func (c *Client) AddRs(rs string) error {
 		},
 		EbgpMultihop: &api.EbgpMultihop{
 			Enabled:     true,
-			MultihopTtl: 10,
+			MultihopTtl: multihop,
 		},
 		Timers: &api.Timers{
 			Config: &api.TimersConfig{

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func main() {
 		false,
 		"Consider all interfaces when detecting elastic IP candidates (not just loopback)",
 	)
+	multihopTtl := flag.Int("multihopttl", 16, "TTL for eBGP multihop neighbors")
 	neighborPattern := flag.String("neighborpattern", defaultNeighborPattern, "The pattern to use for generating neighbor addresses. Only use this when running lelastic outside of production Linode datacenters.")
 
 	flag.Parse()
@@ -99,7 +100,7 @@ func main() {
 
 	for i := 1; i <= 4; i++ {
 		var rs = fmt.Sprintf(*neighborPattern, *dcid, i)
-		if err := c.AddRs(rs); err != nil {
+		if err := c.AddRs(rs, uint32(*multihopTtl)); err != nil {
 			log.WithFields(log.Fields{"Topic": "Neighbor", "Neighbor": rs}).Fatal("failed adding neighbor")
 		}
 		// log.WithFields(log.Fields{"Topic": "Neighbor", "Neighbor": rs}).Info("added neighbor")


### PR DESCRIPTION
Making the value of MultihopTtl for the RS peering session parametrizable.
Default value raised to 16.

Usage example:

```bash
./lelastic -dcid 2 -primary -multihopttl 15
```